### PR TITLE
feat: 모임 생성시 S3 로 이미지 저장하기

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5' // JSON 파싱용
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.github.cdimascio:dotenv-java:3.2.0'
-
+    implementation 'software.amazon.awssdk:s3:2.25.19'
 
 
 

--- a/backend/src/main/java/com/example/tomo/Moim/Moim.java
+++ b/backend/src/main/java/com/example/tomo/Moim/Moim.java
@@ -34,6 +34,8 @@ public class Moim {
     @Lob
     private String description;
 
+    private String imageUrl;
+
     public Moim() {
     }
 
@@ -63,5 +65,9 @@ public class Moim {
     public void addPromise(Promise promise) {
         promises.add(promise);
         promise.setMoimBasedPromise(this);
+    }
+
+    public void updateUrl(String imageUrl){
+        this.imageUrl = imageUrl;
     }
 }

--- a/backend/src/main/java/com/example/tomo/Moim/MoimController.java
+++ b/backend/src/main/java/com/example/tomo/Moim/MoimController.java
@@ -7,10 +7,16 @@ import com.example.tomo.global.ReponseType.ApiResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -33,11 +39,60 @@ public class MoimController {
     /* =====================
        모임 생성
        ===================== */
-    @PostMapping(consumes = "application/json")
+    /* =====================
+   모임 생성
+   ===================== */
+
+    @Operation(
+            summary = "모임 생성 (이미지 없음)",
+            description = """
+        대표 이미지 없이 모임을 생성합니다.
+
+        Content-Type: application/json
+        """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "모임 생성 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = MoimResponseDto.class)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<MoimResponseDto>> createMoim(
-            @Valid @RequestBody AddMoimRequestDto dto,
+            @Valid
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "모임 생성 요청 정보",
+                    required = true,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = AddMoimRequestDto.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                {
+                                  "title": "개발 스터디",
+                                  "description": "Spring 백엔드 스터디",
+                                  "isPublic": true,
+                                  "emails": ["test@test.com"],
+                                  "location": {
+                                    "latitude": 37.5,
+                                    "longitude": 127.0
+                                  }
+                                }
+                                """
+                            )
+                    )
+            )
+            @RequestBody AddMoimRequestDto dto,
             @AuthenticationPrincipal String uid
     ) {
+
         Moim moim = moimService.createMoim(
                 uid,
                 dto.getTitle(),
@@ -61,19 +116,68 @@ public class MoimController {
                         "모임이 생성되었습니다."
                 ));
     }
+
+
     @Operation(
             summary = "모임 생성 (대표 이미지 선택 가능)",
             description = """
-    모임을 생성하고 대표 이미지를 함께 업로드합니다.
+        모임을 생성하면서 대표 이미지를 함께 업로드합니다.
 
-    - request: 모임 생성 정보(JSON 문자열)
-    - image: JPG 이미지 파일 (선택)
-    """
+        Content-Type: multipart/form-data
+
+        - request: 모임 생성 정보(JSON 문자열)
+        - image: JPG 이미지 파일 (선택)
+        """
     )
-    @PostMapping(consumes = "multipart/form-data")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "모임 생성 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = MoimResponseDto.class)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<MoimResponseDto>> createMoimWithImage(
+
+            @Parameter(
+                    description = "모임 생성 정보 (JSON 문자열)",
+                    required = true,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = AddMoimRequestDto.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                {
+                                  "title": "개발 스터디",
+                                  "description": "Spring 백엔드 스터디",
+                                  "isPublic": true,
+                                  "emails": ["test@test.com"],
+                                  "location": {
+                                    "latitude": 37.5,
+                                    "longitude": 127.0
+                                  }
+                                }
+                                """
+                            )
+                    )
+            )
             @RequestPart("request") String requestJson,
+
+            @Parameter(
+                    description = "모임 대표 이미지 (JPG)",
+                    required = false,
+                    content = @Content(
+                            mediaType = MediaType.IMAGE_JPEG_VALUE
+                    )
+            )
             @RequestPart(value = "image", required = false) MultipartFile image,
+
             @AuthenticationPrincipal String uid
     ) throws IOException {
 
@@ -106,6 +210,7 @@ public class MoimController {
                         "모임이 생성되었습니다."
                 ));
     }
+
 
 
     /* =====================

--- a/backend/src/main/java/com/example/tomo/Moim/MoimController.java
+++ b/backend/src/main/java/com/example/tomo/Moim/MoimController.java
@@ -4,6 +4,7 @@ import com.example.tomo.Moim.dtos.MoimQueryResult;
 import com.example.tomo.Moim.dtos.MoimResponseDto;
 import com.example.tomo.Moim.dtos.AddMoimRequestDto;
 import com.example.tomo.global.ReponseType.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,6 +27,8 @@ public class MoimController {
 
     private final MoimService moimService;
     private final MoimResponseAssembler moimResponseAssembler;
+    private final ObjectMapper objectMapper;
+
 
     /* =====================
        모임 생성
@@ -58,13 +61,27 @@ public class MoimController {
                         "모임이 생성되었습니다."
                 ));
     }
+    @Operation(
+            summary = "모임 생성 (대표 이미지 선택 가능)",
+            description = """
+    모임을 생성하고 대표 이미지를 함께 업로드합니다.
+
+    - request: 모임 생성 정보(JSON 문자열)
+    - image: JPG 이미지 파일 (선택)
+    """
+    )
     @PostMapping(consumes = "multipart/form-data")
     public ResponseEntity<ApiResponse<MoimResponseDto>> createMoimWithImage(
-            @Valid @RequestPart("request") AddMoimRequestDto dto,
+            @RequestPart("request") String requestJson,
             @RequestPart(value = "image", required = false) MultipartFile image,
             @AuthenticationPrincipal String uid
     ) throws IOException {
 
+        // 1️⃣ JSON 문자열 → DTO 변환
+        AddMoimRequestDto dto =
+                objectMapper.readValue(requestJson, AddMoimRequestDto.class);
+
+        // 2️⃣ 모임 생성
         Moim moim = moimService.createMoim(
                 uid,
                 dto.getTitle(),
@@ -75,6 +92,7 @@ public class MoimController {
                 image
         );
 
+        // 3️⃣ 응답 조립
         MoimQueryResult result = moimService.getMoim(moim.getId(), uid);
 
         return ResponseEntity
@@ -88,6 +106,7 @@ public class MoimController {
                         "모임이 생성되었습니다."
                 ));
     }
+
 
     /* =====================
        모임 단일 조회

--- a/backend/src/main/java/com/example/tomo/Moim/MoimController.java
+++ b/backend/src/main/java/com/example/tomo/Moim/MoimController.java
@@ -13,7 +13,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @Tag(name = "Moim API", description = "모임 생성, 조회, 삭제 API")
@@ -28,7 +30,7 @@ public class MoimController {
     /* =====================
        모임 생성
        ===================== */
-    @PostMapping
+    @PostMapping(consumes = "application/json")
     public ResponseEntity<ApiResponse<MoimResponseDto>> createMoim(
             @Valid @RequestBody AddMoimRequestDto dto,
             @AuthenticationPrincipal String uid
@@ -39,7 +41,38 @@ public class MoimController {
                 dto.getDescription(),
                 dto.getIsPublic(),
                 dto.getLocation(),
-                dto.getEmails()
+                dto.getEmails(),
+                null
+        );
+
+        MoimQueryResult result = moimService.getMoim(moim.getId(), uid);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(
+                        moimResponseAssembler.toDto(
+                                result.getMoim(),
+                                result.getEmails(),
+                                result.isLeader()
+                        ),
+                        "모임이 생성되었습니다."
+                ));
+    }
+    @PostMapping(consumes = "multipart/form-data")
+    public ResponseEntity<ApiResponse<MoimResponseDto>> createMoimWithImage(
+            @Valid @RequestPart("request") AddMoimRequestDto dto,
+            @RequestPart(value = "image", required = false) MultipartFile image,
+            @AuthenticationPrincipal String uid
+    ) throws IOException {
+
+        Moim moim = moimService.createMoim(
+                uid,
+                dto.getTitle(),
+                dto.getDescription(),
+                dto.getIsPublic(),
+                dto.getLocation(),
+                dto.getEmails(),
+                image
         );
 
         MoimQueryResult result = moimService.getMoim(moim.getId(), uid);

--- a/backend/src/main/java/com/example/tomo/Moim/MoimService.java
+++ b/backend/src/main/java/com/example/tomo/Moim/MoimService.java
@@ -9,10 +9,12 @@ import com.example.tomo.Users.UserErrorCode;
 import com.example.tomo.Users.UserException;
 import com.example.tomo.Users.UserRepository;
 import com.example.tomo.global.Embedded.Location;
+import com.example.tomo.global.S3.S3UploadService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -25,6 +27,7 @@ public class MoimService {
     private final MoimRepository moimRepository;
     private final UserRepository userRepository;
     private final MoimPeopleRepository moimPeopleRepository;
+    private final S3UploadService s3UploadService;
 
     /* =====================
        모임 생성
@@ -36,7 +39,8 @@ public class MoimService {
             String description,
             Boolean isPublic,
             Location location,
-            List<String> emails
+            List<String> emails,
+            MultipartFile image
     ) {
 
         User leader = userRepository.findByFirebaseId(uid)
@@ -59,6 +63,14 @@ public class MoimService {
             }
 
             moim.addMoimPeople(new Moim_people(moim, user, false));
+        }
+
+        if (image != null && !image.isEmpty()) {
+            String imageUrl = s3UploadService.uploadMoimImage(
+                    moim.getId(),
+                    image
+            );
+            moim.updateUrl(imageUrl);
         }
 
         return moim;

--- a/backend/src/main/java/com/example/tomo/global/Config/S3Config.java
+++ b/backend/src/main/java/com/example/tomo/global/Config/S3Config.java
@@ -1,0 +1,35 @@
+package com.example.tomo.global.Config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials =
+                AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(credentials)
+                )
+                .build();
+    }
+}

--- a/backend/src/main/java/com/example/tomo/global/S3/ImageController.java
+++ b/backend/src/main/java/com/example/tomo/global/S3/ImageController.java
@@ -1,0 +1,13 @@
+package com.example.tomo.global.S3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/images")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final S3UploadService s3UploadService;
+}

--- a/backend/src/main/java/com/example/tomo/global/S3/ImageController.java
+++ b/backend/src/main/java/com/example/tomo/global/S3/ImageController.java
@@ -1,8 +1,15 @@
 package com.example.tomo.global.S3;
 
+import com.example.tomo.global.ReponseType.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/images")
@@ -10,4 +17,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class ImageController {
 
     private final S3UploadService s3UploadService;
+
+    @PostMapping
+    public ApiResponse<String> upload(
+            @RequestPart("image") MultipartFile image,
+            @AuthenticationPrincipal String uid
+    ) throws IOException {
+
+        String imageUrl = s3UploadService.upload(image, uid);
+
+        return ApiResponse.success(imageUrl, "이미지 업로드 성공");
+    }
+
+
 }
+

--- a/backend/src/main/java/com/example/tomo/global/S3/S3ErrorCode.java
+++ b/backend/src/main/java/com/example/tomo/global/S3/S3ErrorCode.java
@@ -1,0 +1,24 @@
+package com.example.tomo.global.S3;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum S3ErrorCode {
+
+    S3_UPLOAD_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "이미지 업로드에 실패했습니다."
+    ),
+
+    INVALID_FILE(
+            HttpStatus.BAD_REQUEST,
+            "유효하지 않은 파일입니다."
+    );
+
+    private final HttpStatus status;
+    private final String message;
+}
+

--- a/backend/src/main/java/com/example/tomo/global/S3/S3Exception.java
+++ b/backend/src/main/java/com/example/tomo/global/S3/S3Exception.java
@@ -1,0 +1,19 @@
+package com.example.tomo.global.S3;
+
+import com.example.tomo.global.Exception.BusinessException;
+import lombok.Getter;
+
+@Getter
+public class S3Exception extends BusinessException {
+
+    private final S3ErrorCode errorCode;
+
+    public S3Exception(S3ErrorCode errorCode) {
+        super(
+                errorCode.getMessage(),
+                errorCode.getStatus()
+        );
+        this.errorCode = errorCode;
+    }
+
+}

--- a/backend/src/main/java/com/example/tomo/global/S3/S3UploadService.java
+++ b/backend/src/main/java/com/example/tomo/global/S3/S3UploadService.java
@@ -1,17 +1,76 @@
 package com.example.tomo.global.S3;
 
+import com.example.tomo.Users.User;
+import com.example.tomo.Users.UserErrorCode;
+import com.example.tomo.Users.UserException;
+import com.example.tomo.Users.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class S3UploadService {
 
     private final S3Client s3Client;
+    private final UserRepository userRepository;
 
     @Value("${cloud.aws.s3.bucketName}")
     private String bucketName;
+
+    public String upload(MultipartFile file, String uid) throws IOException {
+        validate(file);
+        User user = userRepository.findByFirebaseId(uid)
+                .orElseThrow(()-> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        Long userId = user.getId();
+
+        // 1. 파일명 생성 (중복 방지)
+        String key = "images/user/" + userId + "/" + UUID.randomUUID() + ".jpg";
+
+
+        // 2. S3 업로드 요청
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(file.getContentType())
+                .build();
+
+        s3Client.putObject(
+                request,
+                RequestBody.fromInputStream(file.getInputStream(), file.getSize())
+        );
+
+        // 3. 접근 가능한 URL 반환
+        return "https://" + bucketName + ".s3.ap-northeast-2.amazonaws.com/" + key;
+    }
+
+    private static final long MAX_SIZE = 5 * 1024 * 1024; // 5MB
+    private static final Set<String> ALLOWED_TYPES =
+            Set.of("image/jpeg", "image/png", "image/webp");
+
+    private void validate(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("빈 파일입니다");
+        }
+
+        if (file.getSize() > MAX_SIZE) {
+            throw new IllegalArgumentException("파일 크기는 5MB 이하만 허용됩니다");
+        }
+
+        if (!ALLOWED_TYPES.contains(file.getContentType())) {
+            throw new IllegalArgumentException("허용되지 않은 이미지 타입입니다");
+        }
+    }
+
 }
+
 

--- a/backend/src/main/java/com/example/tomo/global/S3/S3UploadService.java
+++ b/backend/src/main/java/com/example/tomo/global/S3/S3UploadService.java
@@ -58,53 +58,50 @@ public class S3UploadService {
             Set.of("image/jpeg", "image/png", "image/webp");
 
     private void validate(MultipartFile file) {
-        if (file.isEmpty()) {
-            throw new IllegalArgumentException("빈 파일입니다");
+        if (file == null || file.isEmpty()) {
+            throw new S3Exception(S3ErrorCode.INVALID_FILE);
         }
 
         if (file.getSize() > MAX_SIZE) {
-            throw new IllegalArgumentException("파일 크기는 5MB 이하만 허용됩니다");
+            throw new S3Exception(S3ErrorCode.INVALID_FILE);
         }
 
         if (!ALLOWED_TYPES.contains(file.getContentType())) {
-            throw new IllegalArgumentException("허용되지 않은 이미지 타입입니다");
+            throw new S3Exception(S3ErrorCode.INVALID_FILE);
         }
     }
 
-    public String uploadMoimImage(Long moimId, MultipartFile file) throws IOException {
 
-        // 1️⃣ 파일 검증 (기존 로직 재사용)
-        validate(file);
+    public String uploadMoimImage(Long moimId, MultipartFile file) {
 
-        // 2️⃣ 확장자 처리 (원본 기준)
-        String originalFilename = file.getOriginalFilename();
-        String extension = ".jpg";
+        try {
+            validate(file);
 
-        if (originalFilename != null && originalFilename.contains(".")) {
-            extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+            String originalFilename = file.getOriginalFilename();
+            String extension = ".jpg";
+            if (originalFilename != null && originalFilename.contains(".")) {
+                extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+            }
+
+            String key = "images/moim/" + moimId + "/cover/" + UUID.randomUUID() + extension;
+
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .build();
+
+            s3Client.putObject(
+                    request,
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize())
+            );
+
+            return "https://" + bucketName + ".s3.ap-northeast-2.amazonaws.com/" + key;
+
+        } catch (IOException e) {
+            throw new S3Exception(S3ErrorCode.S3_UPLOAD_FAILED);
         }
-
-        // 3️⃣ S3 key 생성 (모임 대표 이미지 경로)
-        String key = "images/moim/" + moimId + "/cover/" + UUID.randomUUID() + extension;
-
-        // 4️⃣ S3 업로드
-        PutObjectRequest request = PutObjectRequest.builder()
-                .bucket(bucketName)
-                .key(key)
-                .contentType(file.getContentType())
-                .build();
-
-        s3Client.putObject(
-                request,
-                RequestBody.fromInputStream(file.getInputStream(), file.getSize())
-        );
-
-        // 5️⃣ 접근 URL 반환
-        return "https://" + bucketName + ".s3.ap-northeast-2.amazonaws.com/" + key;
     }
-
-
-
 
 }
 

--- a/backend/src/main/java/com/example/tomo/global/S3/S3UploadService.java
+++ b/backend/src/main/java/com/example/tomo/global/S3/S3UploadService.java
@@ -26,7 +26,7 @@ public class S3UploadService {
     @Value("${cloud.aws.s3.bucketName}")
     private String bucketName;
 
-    public String upload(MultipartFile file, String uid) throws IOException {
+    public String upload (MultipartFile file, String uid) throws IOException {
         validate(file);
         User user = userRepository.findByFirebaseId(uid)
                 .orElseThrow(()-> new UserException(UserErrorCode.USER_NOT_FOUND));
@@ -70,6 +70,41 @@ public class S3UploadService {
             throw new IllegalArgumentException("허용되지 않은 이미지 타입입니다");
         }
     }
+
+    public String uploadMoimImage(Long moimId, MultipartFile file) throws IOException {
+
+        // 1️⃣ 파일 검증 (기존 로직 재사용)
+        validate(file);
+
+        // 2️⃣ 확장자 처리 (원본 기준)
+        String originalFilename = file.getOriginalFilename();
+        String extension = ".jpg";
+
+        if (originalFilename != null && originalFilename.contains(".")) {
+            extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+        }
+
+        // 3️⃣ S3 key 생성 (모임 대표 이미지 경로)
+        String key = "images/moim/" + moimId + "/cover/" + UUID.randomUUID() + extension;
+
+        // 4️⃣ S3 업로드
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(file.getContentType())
+                .build();
+
+        s3Client.putObject(
+                request,
+                RequestBody.fromInputStream(file.getInputStream(), file.getSize())
+        );
+
+        // 5️⃣ 접근 URL 반환
+        return "https://" + bucketName + ".s3.ap-northeast-2.amazonaws.com/" + key;
+    }
+
+
+
 
 }
 

--- a/backend/src/main/java/com/example/tomo/global/S3/S3UploadService.java
+++ b/backend/src/main/java/com/example/tomo/global/S3/S3UploadService.java
@@ -1,0 +1,17 @@
+package com.example.tomo.global.S3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Service
+@RequiredArgsConstructor
+public class S3UploadService {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucketName}")
+    private String bucketName;
+}
+

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -6,6 +6,13 @@ spring.datasource.password=${DB_PASSWORD}
 jwt.secret=${JWT}
 server.port=${SERVER_PORT:8081}
 
+# AWS S3 ?? ??
+cloud.aws.s3.bucketName=${AWS_S3_BUCKET}
+cloud.aws.credentials.accessKey=${AWS_ACCESS_KEY}
+cloud.aws.credentials.secretKey=${AWS_SECRET_KEY}
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.stack.auto=false
+
 
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 


### PR DESCRIPTION
## 작업 내용
- [x] 모임 생성 시 대표 이미지 업로드 기능 추가
- [x] multipart/form-data 기반 요청 방식으로 확장
- [x] S3 업로드 후 imageUrl 저장 및 응답에 포함

---

## API 명세

기능 | Method | Endpoint | 엔드 포인트변경 여부 |
-- | -- | -- | -- |
모임 생성 (이미지 포함) | POST | /public/moims | 변경 |

- 혹시 몰라서 기존 API 도 남겨뒀습니다. 
---

## 요청 방식

- Content-Type: `multipart/form-data`
- 요청 파라미터 구성
  - `request` : 모임 생성 정보 (JSON 문자열)
  - `image` : 모임 대표 이미지 (선택)

---

## 요청 예시

### form-data

key | type | required | description |
-- | -- | -- | -- |
request | text | O | 모임 생성 정보(JSON 문자열) |
image | file | X | 모임 대표 이미지 |

### request (JSON 문자열로 넘기기 ) 
> 전달 타입은 multipart/form-data

### request
```json
{
  "title": "개발새발23",
  "description": "택민이를 따르라",
  "emails": ["dreamkms2014@gmail.com"],
  "isPublic": false,
  "location": {
    "latitude": 20,
    "longitude": 29
  }
}

```
### response
```json
{
    "success": true,
    "message": "모임이 생성되었습니다.",
    "data": {
        "moimId": 32,
        "title": "개발새발23",
        "description": "택민이를 따르라",
        "emails": [
            "chris212375@gmail.com",
            "dreamkms2014@gmail.com"
        ],
        "location": {
            "latitude": 20,
            "longitude": 29
        },
        "leader": false,
        "createdAt": "2026-01-06",
        "isPublic": false,
        "imageUrl": null
    }
}
```


### 모임 생성 API 요청 예시 (curl)

```bash
curl -X POST "http://localhost:8080/public/moims" \
  -H "Authorization: Bearer {ACCESS_TOKEN}" \
  -H "Content-Type: multipart/form-data" \
  -F 'request={
    "title": "가족모임",
    "description": "연말 가족 모임입니다",
    "isPublic": true,
    "location": "서울",
    "emails": [
      "test1@email.com",
      "test2@email.com"
    ]
  }' \
  -F "image=@/path/to/image.jpg"
